### PR TITLE
Wrong default StringDeserializer instead of StringSerializer fixed in KafkaProducerConfigBeanInfo plus error handling fixed

### DIFF
--- a/src/main/java/com/di/jmeter/kafka/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/di/jmeter/kafka/config/KafkaConsumerConfig.java
@@ -72,7 +72,7 @@ public class KafkaConsumerConfig extends ConfigTestElement
         JMeterVariables variables = getThreadContext().getVariables();
 
         if (variables.getObject(kafkaConsumerClientVariableName) != null) {
-            LOGGER.error("Kafka consumer is already running..");
+            LOGGER.error("Kafka consumer is already running.");
         } else {
             synchronized (this) {
                 try {
@@ -81,8 +81,7 @@ public class KafkaConsumerConfig extends ConfigTestElement
                     variables.putObject(kafkaConsumerClientVariableName, kafkaConsumer);
                     LOGGER.info("Kafka consumer client successfully Initialized");
                 } catch (Exception e) {
-                    LOGGER.error("Error establishing kafka consumer client !!");
-                    e.printStackTrace();
+                    LOGGER.error("Error establishing kafka consumer client!", e);
                 }
             }
         }

--- a/src/main/java/com/di/jmeter/kafka/config/KafkaProducerConfig.java
+++ b/src/main/java/com/di/jmeter/kafka/config/KafkaProducerConfig.java
@@ -74,7 +74,7 @@ public class KafkaProducerConfig extends ConfigTestElement
 		JMeterVariables variables = getThreadContext().getVariables();
 
 		if (variables.getObject(kafkaProducerClientVariableName) != null) {
-			LOGGER.error("Kafka Client is already running..");
+			LOGGER.error("Kafka Client is already running.");
 		} else {
 			synchronized (this) {
 				try {
@@ -82,8 +82,7 @@ public class KafkaProducerConfig extends ConfigTestElement
 					variables.putObject(kafkaProducerClientVariableName, kafkaProducer);
 					LOGGER.info("Kafka Producer client successfully Initialized");
 				} catch (Exception e) {
-					LOGGER.error("Error establishing Kafka producer client !!");
-					e.printStackTrace();
+					LOGGER.error("Error establishing Kafka producer client!", e);
 				}
 			}
 		}

--- a/src/main/java/com/di/jmeter/kafka/config/KafkaProducerConfigBeanInfo.java
+++ b/src/main/java/com/di/jmeter/kafka/config/KafkaProducerConfigBeanInfo.java
@@ -86,13 +86,13 @@ public class KafkaProducerConfigBeanInfo extends BeanInfoSupport{
 
 		connectionConfigPropDesc =  property("serializerKey");
 		connectionConfigPropDesc.setValue(NOT_UNDEFINED, Boolean.TRUE);
-		connectionConfigPropDesc.setValue(DEFAULT, "org.apache.kafka.common.serialization.StringDeserializer");
+		connectionConfigPropDesc.setValue(DEFAULT, "org.apache.kafka.common.serialization.StringSerializer");
 		connectionConfigPropDesc.setDisplayName("Serializer Key");
 		connectionConfigPropDesc.setShortDescription("Serializer Key");
 
 		connectionConfigPropDesc =  property("serializerValue");
 		connectionConfigPropDesc.setValue(NOT_UNDEFINED, Boolean.TRUE);
-		connectionConfigPropDesc.setValue(DEFAULT, "org.apache.kafka.common.serialization.StringDeserializer");
+		connectionConfigPropDesc.setValue(DEFAULT, "org.apache.kafka.common.serialization.StringSerializer");
 		connectionConfigPropDesc.setDisplayName("Serializer Value");
 		connectionConfigPropDesc.setShortDescription("Serializer Value (must accept String input)");
 


### PR DESCRIPTION
The default for key and value serialize were wrong in KafkaProducerConfigBeanInfo. It was `org.apache.kafka.common.serialization.StringDeserializer` instead of `org.apache.kafka.common.serialization.StringSerializer`.

I also fixed the Kafka client creation. The error message was passed to the logger (Log Viewer in JMeter), but the cause and stack  trace to stderr.